### PR TITLE
Lets the parser recognize new HTML5 body tags.

### DIFF
--- a/lib/HTML/TreeBuilder.pm
+++ b/lib/HTML/TreeBuilder.pm
@@ -80,6 +80,12 @@ our @ISA = qw(HTML::Element HTML::Parser);
 *HTML::TreeBuilder::isFormElement       = \%HTML::Tagset::isFormElement;
 *HTML::TreeBuilder::p_closure_barriers  = \@HTML::Tagset::p_closure_barriers;
 
+# Add some body tags that are valid HTML5, but not part of HTML::Tagset.
+foreach (qw(article aside details figcaption figure footer header main
+            mark nav section summary time)) {
+    $HTML::TreeBuilder::isBodyElement{$_}=1;
+}
+
 #==========================================================================
 # Two little shortcut constructors:
 

--- a/t/body.t
+++ b/t/body.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 18;
+use Test::More tests => 19;
 
 use HTML::TreeBuilder;
 
@@ -67,6 +67,13 @@ OTHER_LANGUAGES: {
     is( $html->as_HTML(),
         "<html><head></head><body>Geb&uuml;hr vor Ort von &euro; 30,- pro Woche</body></html>"
     );
+}
+
+HTML5_TAGS: {
+    my $root   = HTML::TreeBuilder->new();
+    my $data   = '<section>Hello!</section>';
+    my $html   = $root->parse($data)->eof->elementify();
+    is( $html->as_HTML(), "<html><head></head><body><section>Hello!</section></body></html>" );
 }
 
 RT_18570: {


### PR DESCRIPTION
This simple change adds a list of valid new-to-HTML5 tags to one of the module's internal hashes of valid tags. This fixes the issue described in [RT #84526](https://rt.cpan.org/Public/Bug/Display.html?id=84526).

The root cause of this issue lies within HTML::Tagset, but [its maintainer is on-record of not supporting this change within that module](https://rt.cpan.org/Public/Bug/Display.html?id=67299#txn-1725341), and has been for several years. So, I propose adding it here instead.

(This patch takes the same tack I have had to take with [some of my own code that uses HTML::TreeBuilder](https://github.com/jmacdotorg/microformats2-perl/blob/master/lib/Web/Microformats2/Parser.pm#L42).)