### PR TITLE
fixed exception error when a single-character attribute name is included

### DIFF
--- a/lib/HTML/Element.pm
+++ b/lib/HTML/Element.pm
@@ -4400,7 +4400,7 @@ sub _valid_name {
     my $attr = shift
         or Carp::croak("sub valid_name requires an attribute name");
 
-    return (0) unless ( $attr =~ /^$START_CHAR$NAME_CHAR+$/ );
+    return (0) unless ( $attr =~ /^$START_CHAR$NAME_CHAR*$/ );
 
     return (1);
 }

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -11,7 +11,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 use HTML::TreeBuilder;
 
 my $tb = HTML::TreeBuilder->new();
@@ -32,6 +32,11 @@ like(
     qr|img has an invalid attribute name 'inval!d'|,
     'catch invalid atribute names'
 );
+
+#
+my $html2 = HTML::TreeBuilder->new_from_content('<img n="ame">');
+my $ret = eval { $html2->as_XML(); };
+ok $ret, "single-character attribute names are valid.";
 
 # xhtml
 my $xhtml = HTML::TreeBuilder->new_from_content(q{<img src="foo.gif" />});


### PR DESCRIPTION
The specification and code do not match.

### spec

https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Name
Name ::= NameStartChar (NameChar)*

### code
  https://github.com/kentfredric/HTML-Tree/blob/6ba11171c101895347c5584b5c3b20c4ee0161e2/lib/HTML/Element.pm#L4403

### The one-liner that causes this error.

    % perl -e "use HTML::TreeBuilder; HTML::TreeBuilder->new->parse_content('<span v="1"></span>')->as_XML"
    span has an invalid attribute name 'v' at -e line 1.